### PR TITLE
Added Functionality to only accept attendance queries at the designated time.

### DIFF
--- a/dev_day_attendance/attendance/models.py
+++ b/dev_day_attendance/attendance/models.py
@@ -19,7 +19,7 @@ class DevDayAttendence(Document):
     reference_code = StringField(required=True)
     att_code = StringField(required=True)
 class Event(Document):
-    event_name=StringField(required=True)
+    competitionName=StringField(required=True)
     start_time=DateTimeField(required=True)
     end_time=DateTimeField(required=True)
 class Attendance(Document):

--- a/dev_day_attendance/attendance/views.py
+++ b/dev_day_attendance/attendance/views.py
@@ -16,11 +16,11 @@ def landingpage(request):
                 utcTime= currentTime.astimezone(pytz.utc) # we have to convert PKT time to UTC, since mongo
                                                           # stores time fields automatically in UTC
                 if utcTime<eventDetails.start_time.replace(tzinfo=pytz.utc):
-                    return render(request, "html/intro.html", {"msg":"Error: Event has not started yet"})
+                    return render(request, "html/intro.html", {"msg":"Error: Competition has not started yet"})
                 elif utcTime>eventDetails.end_time.replace(tzinfo=pytz.utc):
-                    return render(request, "html/intro.html", {"msg":"Error: Event has ended"})
+                    return render(request, "html/intro.html", {"msg":"Error: Competition has ended"})
             except:
-                return render(request, "html/intro.html", {"msg":"Error: Event details not found"})
+                return render(request, "html/intro.html", {"msg":"Error: Competition details not found"})
            
             try:
                 attendanceObj= Attendance.objects.get(teamName=record.team_name)

--- a/dev_day_attendance/attendance/views.py
+++ b/dev_day_attendance/attendance/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render
 from django.http import HttpResponse
 from .models import *
+from datetime import datetime
+import pytz
 
 
 def landingpage(request):
@@ -8,6 +10,18 @@ def landingpage(request):
         code= request.POST["code"]
         try:
             record= DevDayAttendence.objects.get(att_code=code)
+            try:
+                currentTime= datetime.now()
+                eventDetails= Event.objects.get(competitionName=record.comp_name)
+                utcTime= currentTime.astimezone(pytz.utc) # we have to convert PKT time to UTC, since mongo
+                                                          # stores time fields automatically in UTC
+                if utcTime<eventDetails.start_time.replace(tzinfo=pytz.utc):
+                    return render(request, "html/intro.html", {"msg":"Error: Event has not started yet"})
+                elif utcTime>eventDetails.end_time.replace(tzinfo=pytz.utc):
+                    return render(request, "html/intro.html", {"msg":"Error: Event has ended"})
+            except:
+                return render(request, "html/intro.html", {"msg":"Error: Event details not found"})
+           
             try:
                 attendanceObj= Attendance.objects.get(teamName=record.team_name)
                 if attendanceObj.attendanceStatus:


### PR DESCRIPTION
1: a try and except block added in views.py to check for exceptions.
2: within the block there is a simple if else condition
3: It is neccessary to convert all time to UTC since mongo stores dateTime fields in UTC
4: Have to configure Database accordingly ( both date and time ) before prod.
5: Changed event.event_name to event.competitonName since event_name was ambigious?